### PR TITLE
Save the env in case of error

### DIFF
--- a/runner/client/client.py
+++ b/runner/client/client.py
@@ -122,6 +122,6 @@ class Client(object):
 
 if __name__ == "__main__":
     c = Client("th1.mpq.univ-paris-diderot.fr", 47801)
-    c.set_parameters({"nicenessVal": 0, "cpuRangeVal": "0-2", "outputDir": "some_other_dir"})
+    c.set_parameters({"nicenessVal": 0, "cpuRangeVal": "0-2", "outputDir": "some_other_dir"})  #, "environmentName": "myenv.mat})
     c.commit("/Users/mizio/Documents/MizioSpatafora/stefMount/Documents/current", "Another test message")
     c.execute()

--- a/runner/server/main.py
+++ b/runner/server/main.py
@@ -126,6 +126,7 @@ class Runner(object):
         index = self.process.expect(['>>', pexpect.EOF])
         if index == 0:
             self.log.error("Error found")
+            self.process.sendline("save([%s]);" % pdict.get("environmentName", "default.mat"))
             self.process.sendline("exit")
         if index == 1:
             self.log.info("Process completed")


### PR DESCRIPTION
There is a new client option, environmentName that can 
be used to set the env name. Do not forget the file 
extension! Defaults to 'default.mat'.